### PR TITLE
SSTP送信時に改行コードを\nに置換

### DIFF
--- a/nokakoi/FormMain.cs
+++ b/nokakoi/FormMain.cs
@@ -318,7 +318,7 @@ namespace noka
                                         { "Reference5", user?.Picture ?? "https://betoneto.win/media/nokakoi_gray.png" }, // picture
                                         { "Script", $"{speaker}ƒŠƒAƒNƒVƒ‡ƒ“ {userName}\\n{content}\\e" }
                                     };
-                                    string sstpmsg = _SSTPMethod + "\r\n" + String.Join("\r\n", SSTPHeader.Select(kvp => kvp.Key + ": " + kvp.Value)) + "\r\n\r\n";
+                                    string sstpmsg = _SSTPMethod + "\r\n" + String.Join("\r\n", SSTPHeader.Select(kvp => kvp.Key + ": " + kvp.Value.Replace("\n", "\\n"))) + "\r\n\r\n";
                                     string r = _ds.GetSSTPResponse(_ghostName, sstpmsg);
                                     //Debug.WriteLine(r);
                                 }
@@ -374,7 +374,7 @@ namespace noka
                                     { "Reference5", user?.Picture ?? "https://betoneto.win/media/nokakoi_gray.png" }, // picture
                                     { "Script", $"{speaker}{userName}\\n{msg}\\e" }
                                 };
-                                string sstpmsg = _SSTPMethod + "\r\n" + String.Join("\r\n", SSTPHeader.Select(kvp => kvp.Key + ": " + kvp.Value)) + "\r\n\r\n";
+                                string sstpmsg = _SSTPMethod + "\r\n" + String.Join("\r\n", SSTPHeader.Select(kvp => kvp.Key + ": " + kvp.Value.Replace("\n", "\\n"))) + "\r\n\r\n";
                                 string r = _ds.GetSSTPResponse(_ghostName, sstpmsg);
                                 //Debug.WriteLine(r);
                             }


### PR DESCRIPTION
SSTPでは通信規格上、改行コードを値として送信することができないため、`\n`(文字列)を代わりに送信します。
`\n`はバルーン内改行を指示するSakuraScriptです。
(nokakoiの方も同じ不具合がありますので修正願います)